### PR TITLE
fix: export rule config types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import "./rule-types.js";
+export * from "./rule-types.js";
 import type { RuleModule } from "./types.js";
 import { rules as ruleList } from "./utils/rules.js";
 import * as recommended from "./configs/recommended.js";


### PR DESCRIPTION
Reverts ota-meshi/eslint-plugin-markdown-preferences#22