### PR TITLE
feat(markdown-preferences/padding-line-between-blocks): ignore padding following the disable-next-line directive

### DIFF
--- a/src/language/extended-markdown-language.ts
+++ b/src/language/extended-markdown-language.ts
@@ -9,6 +9,7 @@ import type {
   RuleVisitor,
   SourceLocation,
 } from "@eslint/core";
+import type { MarkdownSourceCode } from "@eslint/markdown";
 import markdown from "@eslint/markdown";
 import type {
   MarkdownLanguageContext,
@@ -26,15 +27,24 @@ import type { CustomContainer } from "./ast-types.ts";
 import type { TextSourceCodeBase } from "@eslint/plugin-kit";
 import { parseExtendedMarkdown } from "./parser.ts";
 
-export type ExtendedMarkdownSourceCode = TextSourceCodeBase<{
-  LangOptions: MarkdownLanguageOptions;
-  RootNode: Root;
-  SyntaxElementWithLoc: Node;
-  ConfigNode: {
-    value: string;
-    position: SourceLocation;
-  };
-}>;
+export interface ExtendedMarkdownSourceCode
+  extends TextSourceCodeBase<{
+    LangOptions: MarkdownLanguageOptions;
+    RootNode: Root;
+    SyntaxElementWithLoc: Node;
+    ConfigNode: {
+      value: string;
+      position: SourceLocation;
+    };
+  }> {
+  getInlineConfigNodes(): ReturnType<
+    MarkdownSourceCode["getInlineConfigNodes"]
+  >;
+
+  getDisableDirectives(): ReturnType<
+    MarkdownSourceCode["getDisableDirectives"]
+  >;
+}
 
 export class ExtendedMarkdownLanguage implements Language {
   /**

--- a/src/rules/padding-line-between-blocks.ts
+++ b/src/rules/padding-line-between-blocks.ts
@@ -8,7 +8,9 @@ import type {
 } from "../language/ast-types.ts";
 import {
   getHeadingKind,
+  getHTMLCommentValue,
   getThematicBreakMarker,
+  isHTMLComment,
   type MDBlock,
   type MDDefinition,
   type MDFrontmatter,
@@ -352,6 +354,8 @@ export default createRule<Options>("padding-line-between-blocks", {
         const prevBlock = containerNode.children[i];
         const nextBlock = containerNode.children[i + 1];
 
+        if (isIgnore(prevBlock)) continue;
+
         const expected = getExpectedPadding(prevBlock, nextBlock);
         if (expected === null) continue;
 
@@ -459,5 +463,20 @@ export default createRule<Options>("padding-line-between-blocks", {
         containerStack.shift();
       },
     };
+
+    /**
+     * Check if the previous block is ignored
+     */
+    function isIgnore(
+      prevBlock: MDBlockContainer["children"][number],
+    ): boolean {
+      if (isHTMLComment(prevBlock)) {
+        const value = getHTMLCommentValue(prevBlock)!;
+        if (/^\s*(?:eslint|markdownlint)-disable-next-line\b/u.test(value)) {
+          return true;
+        }
+      }
+      return false;
+    }
   },
 });

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -95,6 +95,8 @@ export type MDParent<N extends MDNode> = N extends Root
       : never
     : never;
 
+const RE_HTML_COMMENT = /<!--(.*?)-->/u;
+
 /**
  * Get the parent of a node.
  */
@@ -244,4 +246,19 @@ export function getThematicBreakMarker(
     hasSpaces: /\s/u.test(text),
     text,
   };
+}
+
+/**
+ * Check whether a node is an HTML comment.
+ */
+export function isHTMLComment(node: MDNode): node is Html {
+  return node.type === "html" && RE_HTML_COMMENT.test(node.value);
+}
+
+/**
+ * Get the value of an HTML comment.
+ */
+export function getHTMLCommentValue(node: MDNode): string | null {
+  if (!isHTMLComment(node)) return null;
+  return RE_HTML_COMMENT.exec(node.value)?.[1] ?? null;
 }

--- a/tests/fixtures/rules/padding-line-between-blocks/valid/default-input.md
+++ b/tests/fixtures/rules/padding-line-between-blocks/valid/default-input.md
@@ -5,7 +5,7 @@ Paragraph.
 ## Section
 
 | Table |
-|-------|
+| ----- |
 | Cell  |
 
 Content.
@@ -28,3 +28,9 @@ Content.
 
 [^footnote]: This is a footnote.
 [^footnote2]: This is a footnote.
+
+<!-- eslint-disable-next-line markdown/no-reversed-media-syntax -->
+(x)[x]
+
+<!-- markdownlint-disable-next-line -->
+Foo

--- a/tests/src/rules/padding-line-between-blocks.ts
+++ b/tests/src/rules/padding-line-between-blocks.ts
@@ -7,6 +7,7 @@ import { loadTestCases } from "../../utils/utils.ts";
 import { parseMarkdown } from "../../utils/markdown-parser/parser.ts";
 import assert from "node:assert";
 import plugin from "../../../src/index.ts";
+import eslintMarkdown from "@eslint/markdown";
 
 const syntaxMap: Record<
   Exclude<MarkdownBlockNode["type"], "json" | "toml">,
@@ -127,10 +128,14 @@ describe("requiresBlankLineBetween", () => {
 const tester = new SnapshotRuleTester({
   plugins: {
     "markdown-preferences": plugin,
+    markdown: eslintMarkdown,
   },
   language: "markdown-preferences/extended-syntax",
   languageOptions: {
     frontmatter: "yaml",
+  },
+  rules: {
+    "markdown/no-reversed-media-syntax": "error",
   },
 });
 


### PR DESCRIPTION


related to #174