### PR TITLE
fix: ensure all custom container characters are properly handled

### DIFF
--- a/.changeset/nine-jobs-remain.md
+++ b/.changeset/nine-jobs-remain.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-markdown-preferences": patch
+---
+
+fix: ensure all custom container characters are properly handled

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -47,3 +47,18 @@ jobs:
         run: npm install -D eslint@${{ matrix.eslint-version }}
       - name: Test
         run: npm test
+  # 266
+  test-conditions-development:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js (latest)
+        uses: actions/setup-node@v6
+        with:
+          node-version: latest
+      - name: Install Packages
+        run: npm install
+      - name: Test with `--conditions development`
+        run: npm test
+        env:
+          NODE_OPTIONS: --conditions development

--- a/src/language/extensions/micromark-custom-container.ts
+++ b/src/language/extensions/micromark-custom-container.ts
@@ -94,7 +94,7 @@ export function customContainer(): Extension {
       openToken = effects.enter("customContainer", { _container: true });
       effects.enter("customContainerFence");
       effects.enter("customContainerFenceSequence");
-      return sequence;
+      return sequence(code);
     }
 
     /**
@@ -191,7 +191,7 @@ export function customContainer(): Extension {
       size = 0;
       effects.enter("customContainerFence");
       effects.enter("customContainerFenceSequence");
-      return sequence;
+      return sequence(code);
     }
 
     /**
@@ -264,12 +264,12 @@ export function customContainer(): Extension {
       if (code !== codes.colon) return ok(code);
       return effects.attempt(
         customContainerCloseConstruct,
-        () => {
+        (code_) => {
           self.containerState!._closeFlow = true;
-          return ok;
+          return ok(code_);
         },
         ok,
-      );
+      )(code);
     }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/ota-meshi/eslint-plugin-markdown-preferences/issues/266

This PR ensures all custom containers characters are internally marked as consumed within `micromark` so that "expected character to be consumed" assertion is not triggered when using the dev bundle.

### How to test

`NODE_OPTIONS='--conditions development' tests/src/language/extensions/custom-container.ts`