### PR TITLE
fix(prefer-link-reference-definitions): avoid identifier collisions

### DIFF
--- a/.changeset/calm-links-agree.md
+++ b/.changeset/calm-links-agree.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-markdown-preferences": patch
+---
+
+fix(markdown-preferences/prefer-link-reference-definitions): avoid case-insensitive reference identifier collisions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for `eslint-plugin-markdown-preferences`
+# Repository Instructions for Coding Agents
 
 This document provides guidelines for AI coding agents to work efficiently in this repository.
 
@@ -170,4 +170,4 @@ Below are the main npm scripts useful for development:
 Refer to [`CONTRIBUTING.md`] for more details.
 
 [`@eslint/markdown`]: https://github.com/eslint/markdown
-[`CONTRIBUTING.md`]: ../CONTRIBUTING.md
+[`CONTRIBUTING.md`]: ./CONTRIBUTING.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,14 @@ If you are addressed in Japanese, please conduct the conversation in Japanese.
 
 ## Development Workflow
 
+### General Quality Standard
+
+For every task, make a deliberate best effort to prevent mistakes.
+
+Before finalizing work, re-read the user's request and all applicable instructions, inspect the complete result in context, challenge your assumptions, and evaluate correctness, simplicity, consistency, edge cases, unintended effects, maintainability, and validation adequacy.
+
+Actively look for problems beyond explicit requirements, examples, checklists, tests, and automated checks. Do not treat any checklist or passing test suite as an exhaustive guarantee. Investigate remaining uncertainty and resolve every known concern before claiming completion.
+
 ### Adding a New Rule
 
 1. Use `npm run new -- <rule-name>` to generate a template for the new rule.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "micromark-extension-math": "^3.1.0",
         "micromark-factory-space": "^2.0.1",
         "micromark-util-character": "^2.1.1",
+        "micromark-util-normalize-identifier": "^2.0.1",
         "micromark-util-symbol": "^2.0.1",
         "string-width": "^8.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "micromark-extension-math": "^3.1.0",
     "micromark-factory-space": "^2.0.1",
     "micromark-util-character": "^2.1.1",
+    "micromark-util-normalize-identifier": "^2.0.1",
     "micromark-util-symbol": "^2.0.1",
     "string-width": "^8.0.0"
   },

--- a/src/rules/prefer-link-reference-definitions.ts
+++ b/src/rules/prefer-link-reference-definitions.ts
@@ -68,23 +68,27 @@ export default createRule<[{ minLinks?: number }?]>(
           string,
           Map<string | null, ResourceNodes>
         >();
-        const definitionIdentifiers = new Set(
-          definitions.map((definition) =>
-            normalizeIdentifier(definition.identifier),
-          ),
-        );
+        const definitionIdentifiers = new Set<string>();
+        const firstDefinitionByIdentifier = new Map<string, Definition>();
+        for (const definition of definitions) {
+          const identifier = normalizeIdentifier(definition.identifier);
+          definitionIdentifiers.add(identifier);
+          if (!firstDefinitionByIdentifier.has(identifier)) {
+            firstDefinitionByIdentifier.set(identifier, definition);
+          }
+        }
         for (const link of links) {
           getResourceNodes(link).links.push(link);
         }
         for (const reference of references) {
-          const definition = definitions.find(
-            (def) => def.identifier === reference.identifier,
+          const definition = firstDefinitionByIdentifier.get(
+            normalizeIdentifier(reference.identifier),
           );
           if (definition) {
             getResourceNodes(definition).references.push(reference);
           }
         }
-        for (const definition of definitions) {
+        for (const definition of firstDefinitionByIdentifier.values()) {
           getResourceNodes(definition).definitions.push(definition);
         }
 

--- a/src/rules/prefer-link-reference-definitions.ts
+++ b/src/rules/prefer-link-reference-definitions.ts
@@ -68,11 +68,9 @@ export default createRule<[{ minLinks?: number }?]>(
           string,
           Map<string | null, ResourceNodes>
         >();
-        const definitionIdentifiers = new Set<string>();
         const firstDefinitionByIdentifier = new Map<string, Definition>();
         for (const definition of definitions) {
           const identifier = normalizeIdentifier(definition.identifier);
-          definitionIdentifiers.add(identifier);
           if (!firstDefinitionByIdentifier.has(identifier)) {
             firstDefinitionByIdentifier.set(identifier, definition);
           }
@@ -124,13 +122,15 @@ export default createRule<[{ minLinks?: number }?]>(
                   } else {
                     identifier = linkInfo.label.replaceAll(/[[\]]/gu, "-");
                     if (
-                      definitionIdentifiers.has(normalizeIdentifier(identifier))
+                      firstDefinitionByIdentifier.has(
+                        normalizeIdentifier(identifier),
+                      )
                     ) {
                       let seq = 1;
                       const original = identifier;
                       identifier = `${original}-${seq}`;
                       while (
-                        definitionIdentifiers.has(
+                        firstDefinitionByIdentifier.has(
                           normalizeIdentifier(identifier),
                         )
                       ) {

--- a/src/rules/prefer-link-reference-definitions.ts
+++ b/src/rules/prefer-link-reference-definitions.ts
@@ -68,25 +68,27 @@ export default createRule<[{ minLinks?: number }?]>(
           string,
           Map<string | null, ResourceNodes>
         >();
-        const firstDefinitionByIdentifier = new Map<string, Definition>();
+        const effectiveDefinitionByIdentifier = new Map<string, Definition>();
         for (const definition of definitions) {
           const identifier = normalizeIdentifier(definition.identifier);
-          if (!firstDefinitionByIdentifier.has(identifier)) {
-            firstDefinitionByIdentifier.set(identifier, definition);
+          // Markdown uses the first definition when normalized identifiers match,
+          // so do not overwrite it with a shadowed definition.
+          if (!effectiveDefinitionByIdentifier.has(identifier)) {
+            effectiveDefinitionByIdentifier.set(identifier, definition);
           }
         }
         for (const link of links) {
           getResourceNodes(link).links.push(link);
         }
         for (const reference of references) {
-          const definition = firstDefinitionByIdentifier.get(
+          const definition = effectiveDefinitionByIdentifier.get(
             normalizeIdentifier(reference.identifier),
           );
           if (definition) {
             getResourceNodes(definition).references.push(reference);
           }
         }
-        for (const definition of firstDefinitionByIdentifier.values()) {
+        for (const definition of effectiveDefinitionByIdentifier.values()) {
           getResourceNodes(definition).definitions.push(definition);
         }
 
@@ -122,7 +124,7 @@ export default createRule<[{ minLinks?: number }?]>(
                   } else {
                     identifier = linkInfo.label.replaceAll(/[[\]]/gu, "-");
                     if (
-                      firstDefinitionByIdentifier.has(
+                      effectiveDefinitionByIdentifier.has(
                         normalizeIdentifier(identifier),
                       )
                     ) {
@@ -130,7 +132,7 @@ export default createRule<[{ minLinks?: number }?]>(
                       const original = identifier;
                       identifier = `${original}-${seq}`;
                       while (
-                        firstDefinitionByIdentifier.has(
+                        effectiveDefinitionByIdentifier.has(
                           normalizeIdentifier(identifier),
                         )
                       ) {

--- a/src/rules/prefer-link-reference-definitions.ts
+++ b/src/rules/prefer-link-reference-definitions.ts
@@ -7,6 +7,7 @@ import type {
   LinkReference,
   Resource,
 } from "../language/ast-types.ts";
+import { normalizeIdentifier } from "micromark-util-normalize-identifier";
 import { createRule } from "../utils/index.ts";
 
 export default createRule<[{ minLinks?: number }?]>(
@@ -67,6 +68,11 @@ export default createRule<[{ minLinks?: number }?]>(
           string,
           Map<string | null, ResourceNodes>
         >();
+        const definitionIdentifiers = new Set(
+          definitions.map((definition) =>
+            normalizeIdentifier(definition.identifier),
+          ),
+        );
         for (const link of links) {
           getResourceNodes(link).links.push(link);
         }
@@ -114,14 +120,15 @@ export default createRule<[{ minLinks?: number }?]>(
                   } else {
                     identifier = linkInfo.label.replaceAll(/[[\]]/gu, "-");
                     if (
-                      definitions.some((def) => def.identifier === identifier)
+                      definitionIdentifiers.has(normalizeIdentifier(identifier))
                     ) {
                       let seq = 1;
                       const original = identifier;
                       identifier = `${original}-${seq}`;
                       while (
-                        // eslint-disable-next-line no-loop-func -- OK
-                        definitions.some((def) => def.identifier === identifier)
+                        definitionIdentifiers.has(
+                          normalizeIdentifier(identifier),
+                        )
                       ) {
                         identifier = `${original}-${++seq}`;
                       }

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/case-insensitive-identifier-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/case-insensitive-identifier-input.md
@@ -1,0 +1,3 @@
+[Foo](/same) and [Foo](/same).
+
+[foo]: /other

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/case-insensitive-identifier-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/case-insensitive-identifier-input.md
@@ -1,3 +1,5 @@
+# Case-Insensitive Identifiers
+
 [Foo](/same) and [Foo](/same).
 
 [foo]: /other

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/shadowed-definition-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/shadowed-definition-input.md
@@ -1,0 +1,8 @@
+<!-- eslint markdown/no-duplicate-definitions: "off" -->
+
+# Shadowed Definition
+
+[Foo](/same) and [Foo](/same).
+
+[foo]: /other
+[FOO]: /same

--- a/tests/src/rules/__snapshots__/prefer-link-reference-definitions.ts.eslintsnap
+++ b/tests/src/rules/__snapshots__/prefer-link-reference-definitions.ts.eslintsnap
@@ -2,6 +2,33 @@
 
 
 Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/case-insensitive-identifier-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Plugins: unable to serialize
+
+Code:
+  1 | [Foo](/same) and [Foo](/same).
+    | ^~~~~~~~~~~~ [1] ^~~~~~~~~~~~ [2]
+  2 |
+  3 | [foo]: /other
+  4 |
+
+Output:
+  1 | [Foo][Foo-1] and [Foo][Foo-1].
+  2 |
+  3 | [foo]: /other
+  4 |
+  5 | [Foo-1]: /same
+  6 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
 Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/image-input.md
 Language: markdown-preferences/extended-syntax
 LanguageOptions:

--- a/tests/src/rules/__snapshots__/prefer-link-reference-definitions.ts.eslintsnap
+++ b/tests/src/rules/__snapshots__/prefer-link-reference-definitions.ts.eslintsnap
@@ -9,19 +9,23 @@ LanguageOptions:
 Plugins: unable to serialize
 
 Code:
-  1 | [Foo](/same) and [Foo](/same).
-    | ^~~~~~~~~~~~ [1] ^~~~~~~~~~~~ [2]
+  1 | # Case-Insensitive Identifiers
   2 |
-  3 | [foo]: /other
+  3 | [Foo](/same) and [Foo](/same).
+    | ^~~~~~~~~~~~ [1] ^~~~~~~~~~~~ [2]
   4 |
+  5 | [foo]: /other
+  6 |
 
 Output:
-  1 | [Foo][Foo-1] and [Foo][Foo-1].
+  1 | # Case-Insensitive Identifiers
   2 |
-  3 | [foo]: /other
+  3 | [Foo][Foo-1] and [Foo][Foo-1].
   4 |
-  5 | [Foo-1]: /same
+  5 | [foo]: /other
   6 |
+  7 | [Foo-1]: /same
+  8 |
 
 [1] Use link reference definitions instead of inline links.
 [2] Use link reference definitions instead of inline links.

--- a/tests/src/rules/__snapshots__/prefer-link-reference-definitions.ts.eslintsnap
+++ b/tests/src/rules/__snapshots__/prefer-link-reference-definitions.ts.eslintsnap
@@ -169,6 +169,43 @@ Output:
 
 
 Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/shadowed-definition-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Plugins: unable to serialize
+
+Code:
+  1 | <!-- eslint markdown/no-duplicate-definitions: "off" -->
+  2 |
+  3 | # Shadowed Definition
+  4 |
+  5 | [Foo](/same) and [Foo](/same).
+    | ^~~~~~~~~~~~ [1] ^~~~~~~~~~~~ [2]
+  6 |
+  7 | [foo]: /other
+  8 | [FOO]: /same
+  9 |
+
+Output:
+  1 | <!-- eslint markdown/no-duplicate-definitions: "off" -->
+  2 |
+  3 | # Shadowed Definition
+  4 |
+  5 | [Foo][Foo-1] and [Foo][Foo-1].
+  6 |
+  7 | [foo]: /other
+  8 | [FOO]: /same
+  9 |
+ 10 | [Foo-1]: /same
+ 11 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
 Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/test01-input.md
 Language: markdown-preferences/extended-syntax
 LanguageOptions:

--- a/tests/src/rules/prefer-link-reference-definitions.ts
+++ b/tests/src/rules/prefer-link-reference-definitions.ts
@@ -1,7 +1,4 @@
-import assert from "node:assert";
-import { Linter } from "eslint";
 import { SnapshotRuleTester } from "eslint-snapshot-rule-tester";
-import plugin from "../../../src/index.ts";
 import rule from "../../../src/rules/prefer-link-reference-definitions.ts";
 import { loadTestCases } from "../../utils/utils.ts";
 
@@ -12,38 +9,3 @@ tester.run(
   rule as any,
   await loadTestCases("prefer-link-reference-definitions"),
 );
-
-describe("prefer-link-reference-definitions", () => {
-  it("avoids identifiers that differ only in case", () => {
-    const code = `[Foo](/same) and [Foo](/same).
-
-[foo]: /other
-`;
-    const result = new Linter().verifyAndFix(
-      code,
-      [
-        {
-          files: ["**/*.md"],
-          plugins: {
-            "markdown-preferences": plugin,
-          },
-          language: "markdown-preferences/extended-syntax",
-          rules: {
-            "markdown-preferences/prefer-link-reference-definitions": "error",
-          },
-        },
-      ],
-      { filename: "test.md" },
-    );
-
-    assert.strictEqual(
-      result.output,
-      `[Foo][Foo-1] and [Foo][Foo-1].
-
-[foo]: /other
-
-[Foo-1]: /same
-`,
-    );
-  });
-});

--- a/tests/src/rules/prefer-link-reference-definitions.ts
+++ b/tests/src/rules/prefer-link-reference-definitions.ts
@@ -1,4 +1,7 @@
+import assert from "node:assert";
+import { Linter } from "eslint";
 import { SnapshotRuleTester } from "eslint-snapshot-rule-tester";
+import plugin from "../../../src/index.ts";
 import rule from "../../../src/rules/prefer-link-reference-definitions.ts";
 import { loadTestCases } from "../../utils/utils.ts";
 
@@ -9,3 +12,38 @@ tester.run(
   rule as any,
   await loadTestCases("prefer-link-reference-definitions"),
 );
+
+describe("prefer-link-reference-definitions", () => {
+  it("avoids identifiers that differ only in case", () => {
+    const code = `[Foo](/same) and [Foo](/same).
+
+[foo]: /other
+`;
+    const result = new Linter().verifyAndFix(
+      code,
+      [
+        {
+          files: ["**/*.md"],
+          plugins: {
+            "markdown-preferences": plugin,
+          },
+          language: "markdown-preferences/extended-syntax",
+          rules: {
+            "markdown-preferences/prefer-link-reference-definitions": "error",
+          },
+        },
+      ],
+      { filename: "test.md" },
+    );
+
+    assert.strictEqual(
+      result.output,
+      `[Foo][Foo-1] and [Foo][Foo-1].
+
+[foo]: /other
+
+[Foo-1]: /same
+`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- normalize generated reference identifiers before checking for existing definitions
- avoid case-insensitive label collisions that can change link destinations during autofix
- add a regression test and a patch changeset
- declare `micromark-util-normalize-identifier` as a direct dependency

## Root cause

The rule compared an existing definition's normalized `identifier` with a generated identifier derived directly from the link label. Markdown reference labels are case-insensitive, so labels such as `foo` and `Foo` were treated as distinct by the fixer even though Markdown resolves them as the same identifier.

## User impact

Autofixing repeated inline links could add a duplicate reference definition and rewrite a link to an unrelated existing destination. The fixer now chooses a suffixed identifier such as `Foo-1` when the normalized identifier is already in use.

## Validation

- `npm test` (4,304 passing)
- `npm run tsc`
- `npm run lint`
- `npm run build`
- `git diff --check`
