### PR TITLE
Add URL ignore patterns for link reference definitions

### DIFF
--- a/.changeset/neat-links-rest.md
+++ b/.changeset/neat-links-rest.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-markdown-preferences": minor
+---
+
+Add the `ignoreUrlPatterns` option to `markdown-preferences/prefer-link-reference-definitions` for excluding matching link and image URLs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,13 @@ When editing files, please note the following:
 
 ### Rule Testing
 
+#### Fixture-first Rule Test Policy
+
+- Rule behavior tests must use fixtures under `tests/fixtures/rules/<rule-name>/` and load them through the repository's fixture-based test utilities.
+- Do not add inline `valid` or `invalid` rule test cases when the same case can be represented by a fixture.
+- Use a non-fixture testing approach only when the fixture infrastructure cannot express the test. In that exceptional case, add a comment explaining why a fixture cannot be used and keep the non-fixture test as small as possible.
+- Direct unit tests for extracted, general-purpose utilities are not rule behavior tests and may be written without rule fixtures.
+
 #### Creating Test Fixtures
 
 Test fixtures for rules should be organized as follows:

--- a/docs/rules/prefer-link-reference-definitions.md
+++ b/docs/rules/prefer-link-reference-definitions.md
@@ -38,20 +38,23 @@ The rule automatically converts inline links to reference links and adds the ref
 
 ## 🔧 Options
 
-You can configure the minimum number of links required to trigger this rule.
+You can configure the minimum number of links required to trigger this rule and
+ignore link destinations using ordered URL patterns.
 
 ```json
 {
   "markdown-preferences/prefer-link-reference-definitions": [
     "error",
     {
-      "minLinks": 2
+      "minLinks": 2,
+      "ignoreUrlPatterns": ["!/^https?:/iu"]
     }
   ]
 }
 ```
 
 - `minLinks`: The minimum number of links with the same URL to trigger the rule. Default is `2`.
+- `ignoreUrlPatterns`: An ordered list of URL patterns to ignore. Default is `[]`.
 
 ### `minLinks`
 
@@ -60,6 +63,51 @@ The minimum number of links with the same URL to trigger the rule. Default is `2
 - Must be a positive integer (minimum: 1)
 - When set to `1`, all inline links will be converted to reference definitions
 - When set to `2` or higher, only URLs that appear multiple times will be converted
+
+### `ignoreUrlPatterns`
+
+An ordered list of patterns for link and image URLs that the rule should ignore.
+Patterns are matched against the parsed URL, without the link label or title.
+Default is `[]`.
+
+- Plain strings match complete URLs exactly.
+- Regular expressions use the `/pattern/flags` format.
+- A pattern prefixed with `!` removes matching URLs from the ignored set.
+- Patterns are applied in order, so a later pattern can override an earlier one.
+- If the first pattern is prefixed with `!`, all URLs are initially ignored.
+
+For example, the following configuration ignores relative URLs and other
+non-HTTP(S) URLs while continuing to check HTTP(S) URLs:
+
+```json
+{
+  "markdown-preferences/prefer-link-reference-definitions": [
+    "error",
+    {
+      "ignoreUrlPatterns": ["!/^https?:/iu"]
+    }
+  ]
+}
+```
+
+Patterns can be layered to add and remove exceptions. The following
+configuration checks HTTP(S) URLs, ignores URLs on `internal.example.com`, and
+then checks its `/public` paths again:
+
+```json
+{
+  "markdown-preferences/prefer-link-reference-definitions": [
+    "error",
+    {
+      "ignoreUrlPatterns": [
+        "!/^https?:/iu",
+        "/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?(?:[/]|[?#]|$)/iu",
+        "!/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?[/]public(?:[/]|[?#]|$)/iu"
+      ]
+    }
+  ]
+}
+```
 
 ## 📚 Further Reading
 

--- a/src/rule-types.ts
+++ b/src/rule-types.ts
@@ -613,6 +613,7 @@ type MarkdownPreferencesPreferInlineCodeWords = []|[{
 type MarkdownPreferencesPreferLinkReferenceDefinitions = []|[{
   
   minLinks?: number
+  ignoreUrlPatterns?: string[]
 }]
 // ----- markdown-preferences/prefer-linked-words -----
 type MarkdownPreferencesPreferLinkedWords = []|[{

--- a/src/rules/prefer-link-reference-definitions.ts
+++ b/src/rules/prefer-link-reference-definitions.ts
@@ -9,8 +9,14 @@ import type {
 } from "../language/ast-types.ts";
 import { normalizeIdentifier } from "micromark-util-normalize-identifier";
 import { createRule } from "../utils/index.ts";
+import { compilePatternMatcher } from "../utils/pattern-matcher.ts";
+import { toRegExp } from "../utils/regexp.ts";
 
-export default createRule<[{ minLinks?: number }?]>(
+type PreferLinkReferenceDefinitionsOptions = [
+  { minLinks?: number; ignoreUrlPatterns?: string[] }?,
+];
+
+export default createRule<PreferLinkReferenceDefinitionsOptions>(
   "prefer-link-reference-definitions",
   {
     meta: {
@@ -35,6 +41,15 @@ export default createRule<[{ minLinks?: number }?]>(
               default: 2,
               minimum: 1,
             },
+            ignoreUrlPatterns: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+              description:
+                "ordered URL patterns to ignore, with `!` patterns restoring matching URLs",
+              default: [],
+            },
           },
           additionalProperties: false,
         },
@@ -48,6 +63,13 @@ export default createRule<[{ minLinks?: number }?]>(
       const sourceCode = context.sourceCode;
       const options = context.options[0] || {};
       const minLinks = options.minLinks ?? 2;
+      const ignoreUrl = compilePatternMatcher(
+        options.ignoreUrlPatterns ?? [],
+        (pattern) => {
+          const regexp = toRegExp(pattern);
+          return (url: string) => regexp.test(url);
+        },
+      );
 
       const definitions: Definition[] = [];
       const links: (Link | Image)[] = [];
@@ -227,12 +249,13 @@ export default createRule<[{ minLinks?: number }?]>(
 
       return {
         link(node) {
-          if (sourceCode.getText(node).startsWith("[")) {
-            // Ignore <link> and url links
-            links.push(node);
-          }
+          if (ignoreUrl(node.url)) return;
+          // Ignore <link> and url links
+          if (!sourceCode.getText(node).startsWith("[")) return;
+          links.push(node);
         },
         image(node) {
+          if (ignoreUrl(node.url)) return;
           links.push(node);
         },
         "linkReference, imageReference"(node) {

--- a/src/rules/sort-definitions.ts
+++ b/src/rules/sort-definitions.ts
@@ -1,6 +1,7 @@
 import type { Definition, FootnoteDefinition } from "../language/ast-types.ts";
 import { createRule } from "../utils/index.ts";
-import { toRegExp, isRegExp } from "../utils/regexp.ts";
+import { compilePatternMatcher } from "../utils/pattern-matcher.ts";
+import { isRegExp, toRegExp } from "../utils/regexp.ts";
 import { getParent, type MDNode } from "../utils/ast.ts";
 import { calcShortestEditScript } from "../utils/calc-shortest-edit-script.ts";
 import type { RuleTextEdit, RuleTextEditor } from "@eslint/core";
@@ -461,62 +462,28 @@ export default createRule<[{ order?: OrderOption[] }?]>("sort-definitions", {
     function compileMatcher(
       pattern: string[],
     ): (node: DefinitionNode) => boolean {
-      const rules: {
-        negative: boolean;
-        match: (node: DefinitionNode) => boolean;
-      }[] = [];
-      for (const p of pattern) {
-        let negative: boolean, patternStr: string;
-        if (p.startsWith("!")) {
-          // If there is `!` at the beginning, it will be parsed with a negative pattern.
-          negative = true;
-          patternStr = p.substring(1);
-        } else {
-          negative = false;
-          patternStr = p;
-        }
+      return compilePatternMatcher(pattern, (patternStr) => {
         const regex = toRegExp(patternStr);
         if (isRegExp(patternStr)) {
-          rules.push({
-            negative,
-            match: (node) => regex.test(getDefinitionText(node)),
-          });
-        } else {
-          rules.push({
-            negative,
-            match: (node) => {
-              if (node.label === patternStr || node.identifier === patternStr) {
+          return (node: DefinitionNode) => regex.test(getDefinitionText(node));
+        }
+        return (node: DefinitionNode) => {
+          if (node.label === patternStr || node.identifier === patternStr) {
+            return true;
+          }
+          if (node.type === "definition") {
+            if (node.url === patternStr) return true;
+            if (URL.canParse(patternStr) && URL.canParse(node.url)) {
+              const normalizedPattern = normalizedURL(patternStr);
+              const normalizedUrl = normalizedURL(node.url);
+              if (normalizedUrl.startsWith(normalizedPattern)) {
                 return true;
               }
-              if (node.type === "definition") {
-                if (node.url === patternStr) return true;
-                if (URL.canParse(patternStr) && URL.canParse(node.url)) {
-                  const normalizedPattern = normalizedURL(patternStr);
-                  const normalizedUrl = normalizedURL(node.url);
-                  if (normalizedUrl.startsWith(normalizedPattern)) {
-                    return true;
-                  }
-                }
-              }
-              return regex.test(getDefinitionText(node));
-            },
-          });
-        }
-      }
-      return (node) => {
-        // If the first rule is a negative pattern, they are considered to match if they do not match that pattern.
-        let result = Boolean(rules[0]?.negative);
-        for (const { negative, match } of rules) {
-          if (result === !negative) {
-            // Even if it matches, the result does not change, so skip it.
-            continue;
+            }
           }
-          if (match(node)) {
-            result = !negative;
-          }
-        }
-        return result;
-      };
+          return regex.test(getDefinitionText(node));
+        };
+      });
     }
   },
 });

--- a/src/utils/pattern-matcher.ts
+++ b/src/utils/pattern-matcher.ts
@@ -1,0 +1,36 @@
+/**
+ * Compile an ordered list of patterns into a matcher.
+ *
+ * A negated pattern removes matching values from the result, while a regular
+ * pattern adds them. If the first pattern is negated, all values are initially
+ * considered to match. Patterns are applied in order.
+ */
+export function compilePatternMatcher<T>(
+  patterns: string[],
+  compile: (pattern: string) => (value: T) => boolean,
+): (value: T) => boolean {
+  const rules = patterns.map((pattern) => {
+    const negative = pattern.startsWith("!");
+    const patternStr = negative ? pattern.slice(1) : pattern;
+    return {
+      negative,
+      match: compile(patternStr),
+    };
+  });
+
+  return (value) => {
+    // If the first rule is a negative pattern, values are considered to match
+    // until they match that pattern.
+    let result = Boolean(rules[0]?.negative);
+    for (const { negative, match } of rules) {
+      if (result === !negative) {
+        // Even if this rule matches, it cannot change the current result.
+        continue;
+      }
+      if (match(value)) {
+        result = !negative;
+      }
+    }
+    return result;
+  };
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-boundaries-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-boundaries-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": [
+        "!/^https?:/iu",
+        "/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?(?:[/]|[?#]|$)/iu",
+        "!/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?[/]public(?:[/]|[?#]|$)/iu"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-boundaries-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-boundaries-input.md
@@ -1,0 +1,5 @@
+# Documented Layered Pattern Boundaries
+
+[Lookalike](https://internal.example.com.evil.test/private) and [Lookalike](https://internal.example.com.evil.test/private).
+
+[No Boundary](https://internal.example.comevil.test/private) and [No Boundary](https://internal.example.comevil.test/private).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-patterns-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-patterns-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": [
+        "!/^https?:/iu",
+        "/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?(?:[/]|[?#]|$)/iu",
+        "!/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?[/]public(?:[/]|[?#]|$)/iu"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-patterns-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-patterns-input.md
@@ -1,0 +1,33 @@
+# Documented Layered Patterns
+
+[External](https://example.com) and [External](https://example.com).
+
+![External Logo](https://example.com/logo.svg) and ![External Logo](https://example.com/logo.svg).
+
+[Private](https://internal.example.com/private) and [Private](https://internal.example.com/private).
+
+![Private Logo](https://internal.example.com/private/logo.svg) and ![Private Logo](https://internal.example.com/private/logo.svg).
+
+[Private Query](https://internal.example.com?view=private) and [Private Query](https://internal.example.com?view=private).
+
+[Private Fragment](https://internal.example.com#private) and [Private Fragment](https://internal.example.com#private).
+
+[Private Port](https://internal.example.com:8443/private) and [Private Port](https://internal.example.com:8443/private).
+
+[Publicity](https://internal.example.com/publicity) and [Publicity](https://internal.example.com/publicity).
+
+[Public](https://internal.example.com/public/guide) and [Public](https://internal.example.com/public/guide).
+
+[Public HTTP](http://internal.example.com/public) and [Public HTTP](http://internal.example.com/public).
+
+[Public Exact](https://internal.example.com/public) and [Public Exact](https://internal.example.com/public).
+
+[Public Query](https://internal.example.com/public?view=all) and [Public Query](https://internal.example.com/public?view=all).
+
+[Public Fragment](https://internal.example.com/public#guide) and [Public Fragment](https://internal.example.com/public#guide).
+
+[Public Port](https://internal.example.com:8443/public/guide) and [Public Port](https://internal.example.com:8443/public/guide).
+
+![Public Logo](https://internal.example.com/public/logo.svg) and ![Public Logo](https://internal.example.com/public/logo.svg).
+
+[Relative](./guide.md) and [Relative](./guide.md).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-non-http-pattern-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-non-http-pattern-config.json
@@ -1,0 +1,7 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": ["!/^https?:/iu"]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-non-http-pattern-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-non-http-pattern-input.md
@@ -1,0 +1,9 @@
+# Documented Non-HTTP Pattern
+
+[HTTP](http://example.com) and [HTTP](http://example.com).
+
+[HTTPS](https://example.com) and [HTTPS](https://example.com).
+
+[Uppercase](HTTPS://EXAMPLE.COM/GUIDE) and [Uppercase](HTTPS://EXAMPLE.COM/GUIDE).
+
+![HTTP Image](http://example.com/logo.svg) and ![HTTP Image](http://example.com/logo.svg).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-options-overview-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-options-overview-config.json
@@ -1,0 +1,8 @@
+{
+  "options": [
+    {
+      "minLinks": 2,
+      "ignoreUrlPatterns": ["!/^https?:/iu"]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-options-overview-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-options-overview-input.md
@@ -1,0 +1,5 @@
+# Documented Options Overview
+
+[HTTP](http://example.com) and [HTTP](http://example.com).
+
+![HTTPS](https://example.com/logo.svg) and ![HTTPS](https://example.com/logo.svg).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/empty-ignore-url-patterns-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/empty-ignore-url-patterns-config.json
@@ -1,0 +1,7 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": []
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/empty-ignore-url-patterns-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/empty-ignore-url-patterns-input.md
@@ -1,0 +1,3 @@
+# Empty Ignore URL Patterns
+
+[Relative](./guide.md) and [Relative](./guide.md).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/literal-url-pattern-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/literal-url-pattern-config.json
@@ -1,0 +1,7 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": ["./guide.md"]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/literal-url-pattern-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/literal-url-pattern-input.md
@@ -1,0 +1,7 @@
+# Literal URL Pattern
+
+[Ignored](./guide.md) and [Ignored](./guide.md).
+
+[Query](./guide.md?tab=api) and [Query](./guide.md?tab=api).
+
+[Parent](../guide.md) and [Parent](../guide.md).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/min-links-one-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/min-links-one-config.json
@@ -1,0 +1,8 @@
+{
+  "options": [
+    {
+      "minLinks": 1,
+      "ignoreUrlPatterns": ["./guide.md", "./logo.svg"]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/min-links-one-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/min-links-one-input.md
@@ -1,0 +1,9 @@
+# Minimum Links One
+
+[Ignored](./guide.md "Guide").
+
+![Ignored Logo](./logo.svg "Logo").
+
+[Checked](https://example.com).
+
+![Checked Logo](https://example.com/logo.svg).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/multiple-identifier-collisions-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/multiple-identifier-collisions-input.md
@@ -1,0 +1,6 @@
+# Multiple Identifier Collisions
+
+[Foo](/same) and [Foo](/same).
+
+[foo]: /other
+[FOO-1]: /another

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/reapplied-url-pattern-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/reapplied-url-pattern-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": [
+        "https://example.com",
+        "!https://example.com",
+        "https://example.com"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/reapplied-url-pattern-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/reapplied-url-pattern-input.md
@@ -1,0 +1,3 @@
+# Reapplied URL Pattern
+
+[Checked](https://other.example.com) and [Checked](https://other.example.com).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/url-only-pattern-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/url-only-pattern-config.json
@@ -1,0 +1,7 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": ["/ignored/u"]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/invalid/url-only-pattern-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/invalid/url-only-pattern-input.md
@@ -1,0 +1,11 @@
+# URL-Only Pattern Matching
+
+[ignored label](https://example.com) and [ignored label](https://example.com).
+
+[Title](https://title.example "ignored title") and [Title](https://title.example "ignored title").
+
+[Ignored URL](https://ignored.example) and [Ignored URL](https://ignored.example).
+
+![ignored alt](https://image.example/logo.svg) and ![ignored alt](https://image.example/logo.svg).
+
+![Ignored URL](https://ignored.example/logo.svg) and ![Ignored URL](https://ignored.example/logo.svg).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-layered-patterns-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-layered-patterns-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": [
+        "!/^https?:/iu",
+        "/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?(?:[/]|[?#]|$)/iu",
+        "!/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?[/]public(?:[/]|[?#]|$)/iu"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-layered-patterns-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-layered-patterns-input.md
@@ -1,0 +1,21 @@
+# Documented Layered Patterns
+
+[Relative](./guide.md) and [Relative](./guide.md).
+
+[Host](https://internal.example.com) and [Host](https://internal.example.com).
+
+[Root](https://internal.example.com/) and [Root](https://internal.example.com/).
+
+[Private](https://internal.example.com/private) and [Private](https://internal.example.com/private).
+
+[HTTP Private](http://internal.example.com/private) and [HTTP Private](http://internal.example.com/private).
+
+[Query](https://internal.example.com?view=private) and [Query](https://internal.example.com?view=private).
+
+[Fragment](https://internal.example.com#private) and [Fragment](https://internal.example.com#private).
+
+[Port](https://internal.example.com:8443/private) and [Port](https://internal.example.com:8443/private).
+
+[Publicity](https://internal.example.com/publicity) and [Publicity](https://internal.example.com/publicity).
+
+![Private Image](HTTPS://INTERNAL.EXAMPLE.COM/private.svg) and ![Private Image](HTTPS://INTERNAL.EXAMPLE.COM/private.svg).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-non-http-pattern-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-non-http-pattern-config.json
@@ -1,0 +1,7 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": ["!/^https?:/iu"]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-non-http-pattern-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-non-http-pattern-input.md
@@ -1,0 +1,21 @@
+# Documented Non-HTTP Pattern
+
+[Guide](./guide.md) and [Guide](./guide.md).
+
+[Bare](guide.md) and [Bare](guide.md).
+
+[Parent](../guide.md) and [Parent](../guide.md).
+
+[Root](/docs/guide.md) and [Root](/docs/guide.md).
+
+[Anchor](#documented-non-http-pattern) and [Anchor](#documented-non-http-pattern).
+
+[Query](?view=all) and [Query](?view=all).
+
+[Protocol Relative](//cdn.example.com/guide) and [Protocol Relative](//cdn.example.com/guide).
+
+![Logo](./logo.svg) and ![Logo](./logo.svg).
+
+[Email](mailto:user@example.com) and [Email](mailto:user@example.com).
+
+[Telephone](tel:+123456789) and [Telephone](tel:+123456789).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-options-overview-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-options-overview-config.json
@@ -1,0 +1,8 @@
+{
+  "options": [
+    {
+      "minLinks": 2,
+      "ignoreUrlPatterns": ["!/^https?:/iu"]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-options-overview-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/documented-options-overview-input.md
@@ -1,0 +1,7 @@
+# Documented Options Overview
+
+[Only once](https://once.example.com).
+
+[Relative](./guide.md) and [Relative](./guide.md).
+
+![Relative](../logo.svg) and ![Relative](../logo.svg).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/empty-link-label-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/empty-link-label-input.md
@@ -1,0 +1,3 @@
+# Empty Link Labels
+
+[](https://example.com) and [](https://example.com).

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/reapplied-url-pattern-config.json
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/reapplied-url-pattern-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "ignoreUrlPatterns": [
+        "https://example.com",
+        "!https://example.com",
+        "https://example.com"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/prefer-link-reference-definitions/valid/reapplied-url-pattern-input.md
+++ b/tests/fixtures/rules/prefer-link-reference-definitions/valid/reapplied-url-pattern-input.md
@@ -1,0 +1,3 @@
+# Reapplied URL Pattern
+
+[Ignored](https://example.com) and [Ignored](https://example.com).

--- a/tests/src/rules/__snapshots__/prefer-link-reference-definitions.ts.eslintsnap
+++ b/tests/src/rules/__snapshots__/prefer-link-reference-definitions.ts.eslintsnap
@@ -33,6 +33,311 @@ Output:
 
 
 Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-boundaries-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - ignoreUrlPatterns:
+      - "!/^https?:/iu"
+      - /^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?(?:[/]|[?#]|$)/iu
+      - "!/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?[/]public(?:[/]|[?\
+        #]|$)/iu"
+Plugins: unable to serialize
+
+Code:
+  1 | # Documented Layered Pattern Boundaries
+  2 |
+  3 | [Lookalike](https://internal.example.com.evil.test/private) and [Lookalike](https://internal.example.com.evil.test/private).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [2]
+  4 |
+  5 | [No Boundary](https://internal.example.comevil.test/private) and [No Boundary](https://internal.example.comevil.test/private).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [3] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [4]
+  6 |
+
+Output:
+  1 | # Documented Layered Pattern Boundaries
+  2 |
+  3 | [Lookalike] and [Lookalike].
+  4 |
+  5 | [No Boundary] and [No Boundary].
+  6 |
+  7 | [Lookalike]: https://internal.example.com.evil.test/private
+  8 |
+  9 | [No Boundary]: https://internal.example.comevil.test/private
+ 10 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+[3] Use link reference definitions instead of inline links.
+[4] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-layered-patterns-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - ignoreUrlPatterns:
+      - "!/^https?:/iu"
+      - /^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?(?:[/]|[?#]|$)/iu
+      - "!/^https?:[/]{2}internal[.]example[.]com(?::[0-9]+)?[/]public(?:[/]|[?\
+        #]|$)/iu"
+Plugins: unable to serialize
+
+Code:
+  1 | # Documented Layered Patterns
+  2 |
+  3 | [External](https://example.com) and [External](https://example.com).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [2]
+  4 |
+  5 | ![External Logo](https://example.com/logo.svg) and ![External Logo](https://example.com/logo.svg).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [3] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [4]
+  6 |
+  7 | [Private](https://internal.example.com/private) and [Private](https://internal.example.com/private).
+  8 |
+  9 | ![Private Logo](https://internal.example.com/private/logo.svg) and ![Private Logo](https://internal.example.com/private/logo.svg).
+ 10 |
+ 11 | [Private Query](https://internal.example.com?view=private) and [Private Query](https://internal.example.com?view=private).
+ 12 |
+ 13 | [Private Fragment](https://internal.example.com#private) and [Private Fragment](https://internal.example.com#private).
+ 14 |
+ 15 | [Private Port](https://internal.example.com:8443/private) and [Private Port](https://internal.example.com:8443/private).
+ 16 |
+ 17 | [Publicity](https://internal.example.com/publicity) and [Publicity](https://internal.example.com/publicity).
+ 18 |
+ 19 | [Public](https://internal.example.com/public/guide) and [Public](https://internal.example.com/public/guide).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [5] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [6]
+ 20 |
+ 21 | [Public HTTP](http://internal.example.com/public) and [Public HTTP](http://internal.example.com/public).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [7] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [8]
+ 22 |
+ 23 | [Public Exact](https://internal.example.com/public) and [Public Exact](https://internal.example.com/public).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [9] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [10]
+ 24 |
+ 25 | [Public Query](https://internal.example.com/public?view=all) and [Public Query](https://internal.example.com/public?view=all).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    | [11]                                                             [12]
+ 26 |
+ 27 | [Public Fragment](https://internal.example.com/public#guide) and [Public Fragment](https://internal.example.com/public#guide).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    | [13]                                                             [14]
+ 28 |
+ 29 | [Public Port](https://internal.example.com:8443/public/guide) and [Public Port](https://internal.example.com:8443/public/guide).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    | [15]                                                              [16]
+ 30 |
+ 31 | ![Public Logo](https://internal.example.com/public/logo.svg) and ![Public Logo](https://internal.example.com/public/logo.svg).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    | [17]                                                             [18]
+ 32 |
+ 33 | [Relative](./guide.md) and [Relative](./guide.md).
+ 34 |
+
+Output:
+  1 | # Documented Layered Patterns
+  2 |
+  3 | [External] and [External].
+  4 |
+  5 | ![External Logo] and ![External Logo].
+  6 |
+  7 | [Private](https://internal.example.com/private) and [Private](https://internal.example.com/private).
+  8 |
+  9 | ![Private Logo](https://internal.example.com/private/logo.svg) and ![Private Logo](https://internal.example.com/private/logo.svg).
+ 10 |
+ 11 | [Private Query](https://internal.example.com?view=private) and [Private Query](https://internal.example.com?view=private).
+ 12 |
+ 13 | [Private Fragment](https://internal.example.com#private) and [Private Fragment](https://internal.example.com#private).
+ 14 |
+ 15 | [Private Port](https://internal.example.com:8443/private) and [Private Port](https://internal.example.com:8443/private).
+ 16 |
+ 17 | [Publicity](https://internal.example.com/publicity) and [Publicity](https://internal.example.com/publicity).
+ 18 |
+ 19 | [Public] and [Public].
+ 20 |
+ 21 | [Public HTTP] and [Public HTTP].
+ 22 |
+ 23 | [Public Exact] and [Public Exact].
+ 24 |
+ 25 | [Public Query] and [Public Query].
+ 26 |
+ 27 | [Public Fragment] and [Public Fragment].
+ 28 |
+ 29 | [Public Port] and [Public Port].
+ 30 |
+ 31 | ![Public Logo] and ![Public Logo].
+ 32 |
+ 33 | [Relative](./guide.md) and [Relative](./guide.md).
+ 34 |
+ 35 | [External]: https://example.com
+ 36 |
+ 37 | [External Logo]: https://example.com/logo.svg
+ 38 |
+ 39 | [Public]: https://internal.example.com/public/guide
+ 40 |
+ 41 | [Public HTTP]: http://internal.example.com/public
+ 42 |
+ 43 | [Public Exact]: https://internal.example.com/public
+ 44 |
+ 45 | [Public Query]: https://internal.example.com/public?view=all
+ 46 |
+ 47 | [Public Fragment]: https://internal.example.com/public#guide
+ 48 |
+ 49 | [Public Port]: https://internal.example.com:8443/public/guide
+ 50 |
+ 51 | [Public Logo]: https://internal.example.com/public/logo.svg
+ 52 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+[3] Use link reference definitions instead of inline links.
+[4] Use link reference definitions instead of inline links.
+[5] Use link reference definitions instead of inline links.
+[6] Use link reference definitions instead of inline links.
+[7] Use link reference definitions instead of inline links.
+[8] Use link reference definitions instead of inline links.
+[9] Use link reference definitions instead of inline links.
+[10] Use link reference definitions instead of inline links.
+[11] Use link reference definitions instead of inline links.
+[12] Use link reference definitions instead of inline links.
+[13] Use link reference definitions instead of inline links.
+[14] Use link reference definitions instead of inline links.
+[15] Use link reference definitions instead of inline links.
+[16] Use link reference definitions instead of inline links.
+[17] Use link reference definitions instead of inline links.
+[18] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-non-http-pattern-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - ignoreUrlPatterns:
+      - "!/^https?:/iu"
+Plugins: unable to serialize
+
+Code:
+  1 | # Documented Non-HTTP Pattern
+  2 |
+  3 | [HTTP](http://example.com) and [HTTP](http://example.com).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~ [1] ^~~~~~~~~~~~~~~~~~~~~~~~~~ [2]
+  4 |
+  5 | [HTTPS](https://example.com) and [HTTPS](https://example.com).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~ [3] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~ [4]
+  6 |
+  7 | [Uppercase](HTTPS://EXAMPLE.COM/GUIDE) and [Uppercase](HTTPS://EXAMPLE.COM/GUIDE).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [5] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [6]
+  8 |
+  9 | ![HTTP Image](http://example.com/logo.svg) and ![HTTP Image](http://example.com/logo.svg).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [7] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [8]
+ 10 |
+
+Output:
+  1 | # Documented Non-HTTP Pattern
+  2 |
+  3 | [HTTP] and [HTTP].
+  4 |
+  5 | [HTTPS] and [HTTPS].
+  6 |
+  7 | [Uppercase] and [Uppercase].
+  8 |
+  9 | ![HTTP Image] and ![HTTP Image].
+ 10 |
+ 11 | [HTTP]: http://example.com
+ 12 |
+ 13 | [HTTPS]: https://example.com
+ 14 |
+ 15 | [Uppercase]: HTTPS://EXAMPLE.COM/GUIDE
+ 16 |
+ 17 | [HTTP Image]: http://example.com/logo.svg
+ 18 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+[3] Use link reference definitions instead of inline links.
+[4] Use link reference definitions instead of inline links.
+[5] Use link reference definitions instead of inline links.
+[6] Use link reference definitions instead of inline links.
+[7] Use link reference definitions instead of inline links.
+[8] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/documented-options-overview-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - minLinks: 2
+    ignoreUrlPatterns:
+      - "!/^https?:/iu"
+Plugins: unable to serialize
+
+Code:
+  1 | # Documented Options Overview
+  2 |
+  3 | [HTTP](http://example.com) and [HTTP](http://example.com).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~ [1] ^~~~~~~~~~~~~~~~~~~~~~~~~~ [2]
+  4 |
+  5 | ![HTTPS](https://example.com/logo.svg) and ![HTTPS](https://example.com/logo.svg).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [3] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [4]
+  6 |
+
+Output:
+  1 | # Documented Options Overview
+  2 |
+  3 | [HTTP] and [HTTP].
+  4 |
+  5 | ![HTTPS] and ![HTTPS].
+  6 |
+  7 | [HTTP]: http://example.com
+  8 |
+  9 | [HTTPS]: https://example.com/logo.svg
+ 10 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+[3] Use link reference definitions instead of inline links.
+[4] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/empty-ignore-url-patterns-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - ignoreUrlPatterns: []
+Plugins: unable to serialize
+
+Code:
+  1 | # Empty Ignore URL Patterns
+  2 |
+  3 | [Relative](./guide.md) and [Relative](./guide.md).
+    | ^~~~~~~~~~~~~~~~~~~~~~ [1] ^~~~~~~~~~~~~~~~~~~~~~ [2]
+  4 |
+
+Output:
+  1 | # Empty Ignore URL Patterns
+  2 |
+  3 | [Relative] and [Relative].
+  4 |
+  5 | [Relative]: ./guide.md
+  6 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
 Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/image-input.md
 Language: markdown-preferences/extended-syntax
 LanguageOptions:
@@ -83,6 +388,96 @@ Output:
 
 
 Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/literal-url-pattern-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - ignoreUrlPatterns:
+      - ./guide.md
+Plugins: unable to serialize
+
+Code:
+  1 | # Literal URL Pattern
+  2 |
+  3 | [Ignored](./guide.md) and [Ignored](./guide.md).
+  4 |
+  5 | [Query](./guide.md?tab=api) and [Query](./guide.md?tab=api).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~ [1] ^~~~~~~~~~~~~~~~~~~~~~~~~~~ [2]
+  6 |
+  7 | [Parent](../guide.md) and [Parent](../guide.md).
+    | ^~~~~~~~~~~~~~~~~~~~~ [3] ^~~~~~~~~~~~~~~~~~~~~ [4]
+  8 |
+
+Output:
+  1 | # Literal URL Pattern
+  2 |
+  3 | [Ignored](./guide.md) and [Ignored](./guide.md).
+  4 |
+  5 | [Query] and [Query].
+  6 |
+  7 | [Parent] and [Parent].
+  8 |
+  9 | [Query]: ./guide.md?tab=api
+ 10 |
+ 11 | [Parent]: ../guide.md
+ 12 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+[3] Use link reference definitions instead of inline links.
+[4] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/min-links-one-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - minLinks: 1
+    ignoreUrlPatterns:
+      - ./guide.md
+      - ./logo.svg
+Plugins: unable to serialize
+
+Code:
+  1 | # Minimum Links One
+  2 |
+  3 | [Ignored](./guide.md "Guide").
+  4 |
+  5 | ![Ignored Logo](./logo.svg "Logo").
+  6 |
+  7 | [Checked](https://example.com).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1]
+  8 |
+  9 | ![Checked Logo](https://example.com/logo.svg).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [2]
+ 10 |
+
+Output:
+  1 | # Minimum Links One
+  2 |
+  3 | [Ignored](./guide.md "Guide").
+  4 |
+  5 | ![Ignored Logo](./logo.svg "Logo").
+  6 |
+  7 | [Checked].
+  8 |
+  9 | ![Checked Logo].
+ 10 |
+ 11 | [Checked]: https://example.com
+ 12 |
+ 13 | [Checked Logo]: https://example.com/logo.svg
+ 14 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
 Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/mixed-input.md
 Language: markdown-preferences/extended-syntax
 LanguageOptions:
@@ -129,6 +524,39 @@ Output:
 
 
 Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/multiple-identifier-collisions-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Plugins: unable to serialize
+
+Code:
+  1 | # Multiple Identifier Collisions
+  2 |
+  3 | [Foo](/same) and [Foo](/same).
+    | ^~~~~~~~~~~~ [1] ^~~~~~~~~~~~ [2]
+  4 |
+  5 | [foo]: /other
+  6 | [FOO-1]: /another
+  7 |
+
+Output:
+  1 | # Multiple Identifier Collisions
+  2 |
+  3 | [Foo][Foo-2] and [Foo][Foo-2].
+  4 |
+  5 | [foo]: /other
+  6 | [FOO-1]: /another
+  7 |
+  8 | [Foo-2]: /same
+  9 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
 Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/multiple-input.md
 Language: markdown-preferences/extended-syntax
 LanguageOptions:
@@ -162,6 +590,38 @@ Output:
  10 |
  11 | - [ESLint] helps maintain code quality.
  12 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/reapplied-url-pattern-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - ignoreUrlPatterns:
+      - https://example.com
+      - "!https://example.com"
+      - https://example.com
+Plugins: unable to serialize
+
+Code:
+  1 | # Reapplied URL Pattern
+  2 |
+  3 | [Checked](https://other.example.com) and [Checked](https://other.example.com).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [2]
+  4 |
+
+Output:
+  1 | # Reapplied URL Pattern
+  2 |
+  3 | [Checked] and [Checked].
+  4 |
+  5 | [Checked]: https://other.example.com
+  6 |
 
 [1] Use link reference definitions instead of inline links.
 [2] Use link reference definitions instead of inline links.
@@ -347,4 +807,60 @@ Output:
 
 [1] Use link reference definitions instead of inline links.
 [2] Use link reference definitions instead of inline links.
+---
+
+
+Test: prefer-link-reference-definitions >> invalid
+Filename: tests/fixtures/rules/prefer-link-reference-definitions/invalid/url-only-pattern-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - ignoreUrlPatterns:
+      - /ignored/u
+Plugins: unable to serialize
+
+Code:
+  1 | # URL-Only Pattern Matching
+  2 |
+  3 | [ignored label](https://example.com) and [ignored label](https://example.com).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [2]
+  4 |
+  5 | [Title](https://title.example "ignored title") and [Title](https://title.example "ignored title").
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [3] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [4]
+  6 |
+  7 | [Ignored URL](https://ignored.example) and [Ignored URL](https://ignored.example).
+  8 |
+  9 | ![ignored alt](https://image.example/logo.svg) and ![ignored alt](https://image.example/logo.svg).
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [5] ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [6]
+ 10 |
+ 11 | ![Ignored URL](https://ignored.example/logo.svg) and ![Ignored URL](https://ignored.example/logo.svg).
+ 12 |
+
+Output:
+  1 | # URL-Only Pattern Matching
+  2 |
+  3 | [ignored label] and [ignored label].
+  4 |
+  5 | [Title] and [Title].
+  6 |
+  7 | [Ignored URL](https://ignored.example) and [Ignored URL](https://ignored.example).
+  8 |
+  9 | ![ignored alt] and ![ignored alt].
+ 10 |
+ 11 | ![Ignored URL](https://ignored.example/logo.svg) and ![Ignored URL](https://ignored.example/logo.svg).
+ 12 |
+ 13 | [ignored label]: https://example.com
+ 14 |
+ 15 | [Title]: https://title.example "ignored title"
+ 16 |
+ 17 | [ignored alt]: https://image.example/logo.svg
+ 18 |
+
+[1] Use link reference definitions instead of inline links.
+[2] Use link reference definitions instead of inline links.
+[3] Use link reference definitions instead of inline links.
+[4] Use link reference definitions instead of inline links.
+[5] Use link reference definitions instead of inline links.
+[6] Use link reference definitions instead of inline links.
 ---

--- a/tests/src/utils/pattern-matcher.ts
+++ b/tests/src/utils/pattern-matcher.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert";
+import { compilePatternMatcher } from "../../../src/utils/pattern-matcher.ts";
+
+const compilePrefixMatcher = (pattern: string) => (value: string) =>
+  value.startsWith(pattern);
+
+describe("compilePatternMatcher", () => {
+  it("compiles every pattern once and removes one negation prefix", () => {
+    const compiledPatterns: string[] = [];
+
+    compilePatternMatcher(["foo", "!bar", "!!baz"], (pattern) => {
+      compiledPatterns.push(pattern);
+      return () => false;
+    });
+
+    assert.deepStrictEqual(compiledPatterns, ["foo", "bar", "!baz"]);
+  });
+
+  it("does not match values when the pattern list is empty", () => {
+    const match = compilePatternMatcher([], compilePrefixMatcher);
+
+    assert.strictEqual(match("value"), false);
+  });
+
+  it("adds values matched by regular patterns", () => {
+    const match = compilePatternMatcher(["foo", "bar"], compilePrefixMatcher);
+
+    assert.strictEqual(match("foo-value"), true);
+    assert.strictEqual(match("bar-value"), true);
+    assert.strictEqual(match("other"), false);
+  });
+
+  it("starts with all values when the first pattern is negated", () => {
+    const match = compilePatternMatcher(["!foo"], compilePrefixMatcher);
+
+    assert.strictEqual(match("foo-value"), false);
+    assert.strictEqual(match("other"), true);
+  });
+
+  it("excludes values matched by any consecutive negated pattern", () => {
+    const match = compilePatternMatcher(["!foo", "!bar"], compilePrefixMatcher);
+
+    assert.strictEqual(match("foo-value"), false);
+    assert.strictEqual(match("bar-value"), false);
+    assert.strictEqual(match("other"), true);
+  });
+
+  it("subtracts a negated pattern from a regular pattern", () => {
+    const match = compilePatternMatcher(
+      ["item", "!item/public"],
+      compilePrefixMatcher,
+    );
+
+    assert.strictEqual(match("item/private"), true);
+    assert.strictEqual(match("item/public/guide"), false);
+    assert.strictEqual(match("other"), false);
+  });
+
+  it("applies regular and negated patterns in order", () => {
+    const match = compilePatternMatcher(
+      ["!http", "http://internal", "!http://internal/public"],
+      compilePrefixMatcher,
+    );
+
+    assert.strictEqual(match("./guide.md"), true);
+    assert.strictEqual(match("https://example.com"), false);
+    assert.strictEqual(match("http://internal/private"), true);
+    assert.strictEqual(match("http://internal/public/guide"), false);
+  });
+
+  it("supports multiple alternating overrides", () => {
+    const match = compilePatternMatcher(
+      [
+        "item",
+        "!item/public",
+        "item/public/internal",
+        "!item/public/internal/generated",
+      ],
+      compilePrefixMatcher,
+    );
+
+    assert.strictEqual(match("item/private"), true);
+    assert.strictEqual(match("item/public/guide"), false);
+    assert.strictEqual(match("item/public/internal/guide"), true);
+    assert.strictEqual(match("item/public/internal/generated/file"), false);
+  });
+
+  it("supports reapplying the same pattern later", () => {
+    const match = compilePatternMatcher(
+      ["item", "!item", "item"],
+      compilePrefixMatcher,
+    );
+
+    assert.strictEqual(match("item"), true);
+    assert.strictEqual(match("other"), false);
+  });
+
+  it("produces different results when pattern order is reversed", () => {
+    const addThenRemove = compilePatternMatcher(
+      ["item", "!item"],
+      compilePrefixMatcher,
+    );
+    const removeThenAdd = compilePatternMatcher(
+      ["!item", "item"],
+      compilePrefixMatcher,
+    );
+
+    assert.strictEqual(addThenRemove("item"), false);
+    assert.strictEqual(removeThenAdd("item"), true);
+  });
+});


### PR DESCRIPTION
Closes #270.

## Summary

- add an ordered `ignoreUrlPatterns` option to `prefer-link-reference-definitions`
- support regular patterns that add ignored URLs and `!` patterns that restore matching URLs, with later patterns taking precedence
- apply URL filtering to both links and images using their parsed destinations
- extract the ordered matcher into a shared utility and reuse it in `sort-definitions`
- document the option and cover the documented configurations with rule fixtures
- document the repository's fixture-first rule test policy

## Motivation

The rule previously only allowed configuring the minimum occurrence count. Relative links and other destinations therefore could not be excluded without disabling the rule for all links. Ordered URL patterns allow configurations such as `!/^https?:/iu` to ignore non-HTTP(S) destinations while continuing to check external URLs.

## Validation

- `npm run cover` (4,340 passing)
- `npm run lint`
- `npm run tsc`
- `npm run build`
- `npm run docs:build`
