### PR TITLE
Fix Changesets v2 release workflow inputs

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -38,7 +38,7 @@ jobs:
         id: changesets
         uses: changesets/action@v2.0.0
         with:
-          version: npm run changeset:version
-          publish: npm run changeset:publish
+          version-script: npm run changeset:version
+          publish-script: npm run changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changesets Action v2 rejects the legacy `version` and `publish` inputs, so the release workflow stops before creating a version PR or publishing a release.

Use the v2 `version-script` and `publish-script` input names while preserving the existing npm commands.
