### PR TITLE
fix: `indent` to handle task list relativeTo offsets correctly (#322)

### DIFF
--- a/.changeset/tidy-cows-repeat.md
+++ b/.changeset/tidy-cows-repeat.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-markdown-preferences": patch
+---
+
+fix: crash in `indent` rule when `listItems.relativeTo` is not `"taskListMarkerEnd"`
+
+The `markdown-preferences/indent` rule threw `RangeError: Invalid count value` on task list items whenever `listItems.relativeTo` was set to `"markerStart"`, `"markerEnd"`, or `"taskListMarkerStart"`, because the indentation was always measured from the end of the task list marker regardless of the configured reference point.
+
+`"taskListMarkerStart"` is now also implemented (previously it was accepted by the schema but behaved like `"markerEnd"`) and documented, and the documented default is corrected to `"taskListMarkerEnd"`.

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -88,12 +88,24 @@ To control the alignment of list item markers and blockquote markers, use [markd
     - Integer value (`>= 2`): Sets the indentation to the specified number of spaces.
     - `"first"`: Sets the indentation to match the value of `first`.
     - `"minimum"`: Uses the minimum indentation required to maintain indentation.
-  - `relativeTo`: When using a numeric value for indentation, sets the reference point for the indentation. The following values can be used. The default is `"markerEnd"`:
-    - `"markerStart"`: Calculates indentation relative to the start position of the list marker.
+  - `relativeTo`: When using a numeric value for indentation, sets the reference point for the indentation. The following values can be used. The default is `"taskListMarkerEnd"`:
+    - `"markerStart"`: Calculates indentation relative to the start position of the list marker (e.g., the `-` of `- [ ] Foo`, or the `1` of `1. Foo`).
     - `"markerEnd"`: Calculates indentation relative to the end position of the list marker.
-    - `"taskListMarkerEnd"`: Calculates indentation relative to the end position of the task list marker. If the list item is a task list item (e.g., `- [ ]`), the indentation is calculated from the end of the task list marker. If it's a regular list item, it behaves like `"markerEnd"`.
+    - `"taskListMarkerStart"`: Calculates indentation relative to the start position of the task list marker (e.g., the `[` of `- [ ] Foo`). If it's a regular list item, it behaves like `"markerEnd"`.
+    - `"taskListMarkerEnd"`: Calculates indentation relative to the end position of the task list marker (e.g., the `]` of `- [ ] Foo`). If it's a regular list item, it behaves like `"markerEnd"`.
 
-Regardless of the option, if the calculated indentation does not fall within the range allowed by Markdown specifications, the indentation permitted by Markdown specifications will be applied.
+For `"markerStart"` and `"markerEnd"`, the task list marker is treated as part of the list item content, so the indentation that is checked is the one between the list marker and the task list marker. For `"taskListMarkerStart"` and `"taskListMarkerEnd"`, the task list marker is treated as part of the list marker, so the indentation that is checked is the one between the task list marker and the text that follows it.
+
+Regardless of the option, at least one space is always required before the content, and if the calculated indentation does not fall within the range allowed by Markdown specifications, the indentation permitted by Markdown specifications will be applied.
+
+The following table shows how each `relativeTo` value formats the same task list item when `first` is `4`:
+
+| `relativeTo`            | Result         |
+| :---------------------- | :------------- |
+| `"markerStart"`         | `-   [ ] Foo`  |
+| `"markerEnd"`           | `-    [ ] Foo` |
+| `"taskListMarkerStart"` | `- [ ] Foo`    |
+| `"taskListMarkerEnd"`   | `- [ ]    Foo` |
 
 ### Examples
 
@@ -131,6 +143,30 @@ Regardless of the option, if the calculated indentation does not fall within the
      text.
   2. Single line text.
 * Single line text.
+```
+
+<!-- prettier-ignore-end -->
+
+#### `listItems.relativeTo` With Task List Items
+
+<!-- prettier-ignore-start -->
+
+<!-- eslint-skip -->
+
+```md
+<!-- eslint markdown-preferences/indent: ["error", {"listItems": {"first": 4, "other": "first", "relativeTo": "taskListMarkerEnd"}}] -->
+
+<!-- ✓ GOOD -->
+
+- [ ]    Foo
+- [x]    Bar
+         Wrapped text.
+
+<!-- ✗ BAD -->
+
+- [ ] Foo
+- [x] Bar
+  Wrapped text.
 ```
 
 <!-- prettier-ignore-end -->

--- a/src/rules/indent.ts
+++ b/src/rules/indent.ts
@@ -45,11 +45,17 @@ import type { ParsedListItem } from "../utils/list-item.ts";
 import { parseListItem } from "../utils/list-item.ts";
 import { parseMathBlock } from "../utils/math-block.ts";
 
+type RelativeTo =
+  | "markerStart"
+  | "markerEnd"
+  | "taskListMarkerStart"
+  | "taskListMarkerEnd";
+
 type Options = {
   listItems?: {
     first?: number | "ignore";
     other?: number | "first" | "minimum";
-    relativeTo: "markerStart" | "markerEnd" | "taskListMarkerEnd";
+    relativeTo?: RelativeTo;
   };
 };
 
@@ -318,39 +324,72 @@ export default createRule<[Options?]>("indent", {
         }
         if (this._expectedIndentForFirstLine != null)
           return this._expectedIndentForFirstLine;
-        const loc = this.nodeLoc;
+        return (this._expectedIndentForFirstLine = Math.max(
+          this.getRelativeToIndent() + options.listItems.first,
+          // At least one space is required after the content anchor.
+          this.getContentAnchorIndent() + 1,
+        ));
+      }
+
+      /**
+       * Get the index of the position that the content of the list item is
+       * measured from. The content is whatever follows this position, after
+       * the indentation whitespace.
+       *
+       * The task list item marker is part of the content when the indentation
+       * is relative to the list marker, and part of the marker when the
+       * indentation is relative to the task list item marker.
+       */
+      public getContentAnchorIndex(): number {
         const parsed = this.getParsedListItem();
-        const lineText = sourceCode.lines[loc.start.line - 1];
-        if (options.listItems.relativeTo === "markerStart") {
-          const baseIndent = getWidth(lineText.slice(0, loc.start.column - 1));
-          return (this._expectedIndentForFirstLine = Math.max(
-            baseIndent + options.listItems.first,
-            baseIndent + parsed.marker.text.length + 1, // At least one space after the marker,
-          ));
-        }
         if (
-          options.listItems.relativeTo === "taskListMarkerEnd" &&
-          parsed.taskListItemMarker
+          options.listItems.relativeTo === "taskListMarkerStart" ||
+          options.listItems.relativeTo === "taskListMarkerEnd"
         ) {
-          const baseIndent = getWidth(
-            lineText.slice(
-              0,
-              sourceCode.getLocFromIndex(parsed.taskListItemMarker.range[1])
-                .column - 1,
-            ),
-          );
-          return (this._expectedIndentForFirstLine =
-            baseIndent + options.listItems.first);
+          return parsed.taskListItemMarker?.range[1] ?? parsed.marker.range[1];
         }
-        // relative to markerEnd, or taskListMarkerEnd without task list marker
-        const baseIndent = getWidth(
-          lineText.slice(
-            0,
-            sourceCode.getLocFromIndex(parsed.marker.range[1]).column - 1,
-          ),
+        return parsed.marker.range[1];
+      }
+
+      /**
+       * Get the indent width of the content anchor.
+       * See {@link ListItemStack.getContentAnchorIndex}.
+       */
+      private getContentAnchorIndent(): number {
+        return this.getIndentAtIndex(this.getContentAnchorIndex());
+      }
+
+      /**
+       * Get the indent width of the reference point configured by the
+       * `relativeTo` option.
+       */
+      private getRelativeToIndent(): number {
+        const parsed = this.getParsedListItem();
+        if (options.listItems.relativeTo === "markerStart") {
+          return this.getIndentAtIndex(parsed.marker.range[0]);
+        }
+        if (options.listItems.relativeTo === "taskListMarkerStart") {
+          return this.getIndentAtIndex(
+            parsed.taskListItemMarker?.range[0] ?? parsed.marker.range[1],
+          );
+        }
+        if (options.listItems.relativeTo === "taskListMarkerEnd") {
+          return this.getIndentAtIndex(
+            parsed.taskListItemMarker?.range[1] ?? parsed.marker.range[1],
+          );
+        }
+        // markerEnd
+        return this.getIndentAtIndex(parsed.marker.range[1]);
+      }
+
+      /**
+       * Get the width of the text that precedes the given index on its line.
+       */
+      private getIndentAtIndex(index: number): number {
+        const indexLoc = sourceCode.getLocFromIndex(index);
+        return getWidth(
+          sourceCode.lines[indexLoc.line - 1].slice(0, indexLoc.column - 1),
         );
-        return (this._expectedIndentForFirstLine =
-          baseIndent + options.listItems.first);
       }
 
       private getExpectedIndentAfterFirstLine() {
@@ -383,39 +422,18 @@ export default createRule<[Options?]>("indent", {
           return (this._expectedIndentForOtherLines =
             this.getMinimumLineIndent());
         }
-        const lineText = sourceCode.lines[loc.start.line - 1];
+        const baseIndent = this.getRelativeToIndent();
         if (options.listItems.relativeTo === "markerStart") {
-          const baseIndent = getWidth(lineText.slice(0, loc.start.column - 1));
-          const minimumLineIndent = this.getMinimumLineIndent();
           return (this._expectedIndentForOtherLines = Math.max(
             baseIndent + options.listItems.other,
-            minimumLineIndent,
+            this.getMinimumLineIndent(),
           ));
         }
-        const parsed = this.getParsedListItem();
-        if (
-          options.listItems.relativeTo === "taskListMarkerEnd" &&
-          parsed.taskListItemMarker
-        ) {
-          const baseIndent = getWidth(
-            lineText.slice(
-              0,
-              sourceCode.getLocFromIndex(parsed.taskListItemMarker.range[1])
-                .column - 1,
-            ),
-          );
-          return (this._expectedIndentForOtherLines =
-            baseIndent + options.listItems.other);
-        }
-        // relative to markerEnd, or taskListMarkerEnd without task list marker
-        const baseIndent = getWidth(
-          lineText.slice(
-            0,
-            sourceCode.getLocFromIndex(parsed.marker.range[1]).column - 1,
-          ),
-        );
-        return (this._expectedIndentForOtherLines =
-          baseIndent + options.listItems.other);
+        return (this._expectedIndentForOtherLines = Math.max(
+          baseIndent + options.listItems.other,
+          // At least one space is required after the content anchor.
+          this.getContentAnchorIndent() + 1,
+        ));
       }
 
       private getMinimumLineIndent() {
@@ -436,7 +454,7 @@ export default createRule<[Options?]>("indent", {
         const markerEndPos = sourceCode.getLocFromIndex(
           withoutTaskListMarker
             ? parsed.marker.range[1]
-            : (parsed.taskListItemMarker?.range[1] ?? parsed.marker.range[1]),
+            : this.getContentAnchorIndex(),
         );
         const lineText = sourceCode.lines[markerEndPos.line - 1];
         const afterMarkerText = lineText.slice(markerEndPos.column - 1);
@@ -1634,9 +1652,8 @@ export default createRule<[Options?]>("indent", {
       expectedIndentWidth: number;
       actualIndentWidth: number;
     } | null {
-      const parsed = listItem.getParsedListItem();
       const markerAfterColumn = sourceCode.getLocFromIndex(
-        parsed.taskListItemMarker?.range[1] ?? parsed.marker.range[1],
+        listItem.getContentAnchorIndex(),
       ).column;
       const lineText = sourceCode.lines[lineNumber - 1];
       const before = lineText.slice(0, markerAfterColumn - 1);

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-end-config.json
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-end-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 4,
+        "other": "first",
+        "relativeTo": "markerEnd"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-end-input.md
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-end-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+  text.
+
+1. [ ] Foo
+   1. [ ] FooBar
+      Wrapped text.

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-start-config.json
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-start-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 4,
+        "other": "first",
+        "relativeTo": "markerStart"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-start-input.md
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-start-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+  text.
+
+1. [ ] Foo
+   1. [ ] FooBar
+      Wrapped text.

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-end-config.json
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-end-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 4,
+        "other": "first",
+        "relativeTo": "taskListMarkerEnd"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-end-input.md
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-end-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+  text.
+
+1. [ ] Foo
+   1. [ ] FooBar
+      Wrapped text.

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-start-config.json
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-start-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 4,
+        "other": "first",
+        "relativeTo": "taskListMarkerStart"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-start-input.md
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-start-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+  text.
+
+1. [ ] Foo
+   1. [ ] FooBar
+      Wrapped text.

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-ignore-marker-end-config.json
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-ignore-marker-end-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": "ignore",
+        "other": "first",
+        "relativeTo": "markerEnd"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-ignore-marker-end-input.md
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/first-ignore-marker-end-input.md
@@ -1,0 +1,7 @@
+# Task list indentation with an ignored first line
+
+-    [x] Multi line
+  text.
+
+1.   [ ] Multi line
+       text.

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/other-4-task-list-marker-start-config.json
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/other-4-task-list-marker-start-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 1,
+        "other": 4,
+        "relativeTo": "taskListMarkerStart"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/invalid/task-list-relative-to/other-4-task-list-marker-start-input.md
+++ b/tests/fixtures/rules/indent/invalid/task-list-relative-to/other-4-task-list-marker-start-input.md
@@ -1,0 +1,7 @@
+# Task list indentation for lines after the first
+
+- [ ] Multi line
+  text.
+
+1. [ ] Multi line
+   text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/default-marker-end-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/default-marker-end-config.json
@@ -1,0 +1,9 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "relativeTo": "markerEnd"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/default-marker-end-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/default-marker-end-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+  text.
+
+1. [ ] Foo
+   1. [ ] FooBar
+      Wrapped text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/default-marker-start-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/default-marker-start-config.json
@@ -1,0 +1,9 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "relativeTo": "markerStart"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/default-marker-start-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/default-marker-start-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+  text.
+
+1. [ ] Foo
+   1. [ ] FooBar
+      Wrapped text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/default-task-list-marker-end-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/default-task-list-marker-end-config.json
@@ -1,0 +1,9 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "relativeTo": "taskListMarkerEnd"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/default-task-list-marker-end-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/default-task-list-marker-end-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+      text.
+
+1. [ ] Foo
+      1. [ ] FooBar
+             Wrapped text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/default-task-list-marker-start-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/default-task-list-marker-start-config.json
@@ -1,0 +1,9 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "relativeTo": "taskListMarkerStart"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/default-task-list-marker-start-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/default-task-list-marker-start-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+      text.
+
+1. [ ] Foo
+      1. [ ] FooBar
+             Wrapped text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-marker-end-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-marker-end-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 4,
+        "other": "first",
+        "relativeTo": "markerEnd"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-marker-end-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-marker-end-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+-    [ ] Foo
+-    [ ] Bar
+
+*    [x] Multi line
+     text.
+
+1.    [ ] Foo
+      1.    [ ] FooBar
+            Wrapped text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-marker-start-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-marker-start-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 4,
+        "other": "first",
+        "relativeTo": "markerStart"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-marker-start-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-marker-start-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+-   [ ] Foo
+-   [ ] Bar
+
+*   [x] Multi line
+    text.
+
+1.  [ ] Foo
+    1.  [ ] FooBar
+        Wrapped text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-task-list-marker-end-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-task-list-marker-end-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 4,
+        "other": "first",
+        "relativeTo": "taskListMarkerEnd"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-task-list-marker-end-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-task-list-marker-end-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ]    Foo
+- [ ]    Bar
+
+* [x]    Multi line
+         text.
+
+1. [ ]    Foo
+      1. [ ]    FooBar
+                Wrapped text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-task-list-marker-start-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-task-list-marker-start-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 4,
+        "other": "first",
+        "relativeTo": "taskListMarkerStart"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-task-list-marker-start-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-4-task-list-marker-start-input.md
@@ -1,0 +1,11 @@
+# Task list indentation
+
+- [ ] Foo
+- [ ] Bar
+
+* [x] Multi line
+      text.
+
+1. [ ] Foo
+      1. [ ] FooBar
+             Wrapped text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-ignore-marker-end-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-ignore-marker-end-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": "ignore",
+        "other": "first",
+        "relativeTo": "markerEnd"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/first-ignore-marker-end-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/first-ignore-marker-end-input.md
@@ -1,0 +1,7 @@
+# Task list indentation with an ignored first line
+
+-    [x] Multi line
+     text.
+
+1.   [ ] Multi line
+     text.

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/other-4-task-list-marker-start-config.json
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/other-4-task-list-marker-start-config.json
@@ -1,0 +1,11 @@
+{
+  "options": [
+    {
+      "listItems": {
+        "first": 1,
+        "other": 4,
+        "relativeTo": "taskListMarkerStart"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rules/indent/valid/task-list-relative-to/other-4-task-list-marker-start-input.md
+++ b/tests/fixtures/rules/indent/valid/task-list-relative-to/other-4-task-list-marker-start-input.md
@@ -1,0 +1,7 @@
+# Task list indentation for lines after the first
+
+- [ ] Multi line
+      text.
+
+1. [ ] Multi line
+       text.

--- a/tests/src/rules/__snapshots__/indent.ts.eslintsnap
+++ b/tests/src/rules/__snapshots__/indent.ts.eslintsnap
@@ -3306,6 +3306,309 @@ Output:
 
 
 Test: indent >> invalid
+Filename: tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-end-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - listItems:
+      first: 4
+      other: first
+      relativeTo: markerEnd
+Plugins: unable to serialize
+
+Code:
+  1 | # Task list indentation
+  2 |
+  3 | - [ ] Foo
+    |  ^ [1]
+  4 | - [ ] Bar
+    |  ^ [2]
+  5 |
+  6 | * [x] Multi line
+    |  ^ [3]
+  7 |   text.
+    | ^~ [4]
+  8 |
+  9 | 1. [ ] Foo
+    |   ^ [5]
+ 10 |    1. [ ] FooBar
+    | ^~~  ^
+    | [6]  [7]
+ 11 |       Wrapped text.
+    | ^~~~~~ [8]
+ 12 |
+
+Output:
+  1 | # Task list indentation
+  2 |
+  3 | -    [ ] Foo
+  4 | -    [ ] Bar
+  5 |
+  6 | *    [x] Multi line
+  7 |      text.
+  8 |
+  9 | 1.    [ ] Foo
+ 10 |       1.    [ ] FooBar
+ 11 |             Wrapped text.
+ 12 |
+
+[1] Expected indentation of 4 from the list marker but found 1.
+[2] Expected indentation of 4 from the list marker but found 1.
+[3] Expected indentation of 4 from the list marker but found 1.
+[4] Expected indentation of 5 but found 2.
+[5] Expected indentation of 4 from the list marker but found 1.
+[6] Expected indentation of 6 but found 3.
+[7] Expected indentation of 4 from the list marker but found 1.
+[8] Expected indentation of 9 but found 6.
+---
+
+
+Test: indent >> invalid >>> "# Task list indentation\n\n- [ ] Foo\n- [ ] Bar\n\n* [x] Multi line\n  text.\n\n1. [ ] Foo\n   1. [ ] FooBar\n      Wrapped text.\n 2"
+Filename: tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-marker-start-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - listItems:
+      first: 4
+      other: first
+      relativeTo: markerStart
+Plugins: unable to serialize
+
+Code:
+  1 | # Task list indentation
+  2 |
+  3 | - [ ] Foo
+    |  ^ [1]
+  4 | - [ ] Bar
+    |  ^ [2]
+  5 |
+  6 | * [x] Multi line
+    |  ^ [3]
+  7 |   text.
+    | ^~ [4]
+  8 |
+  9 | 1. [ ] Foo
+    |   ^ [5]
+ 10 |    1. [ ] FooBar
+    | ^~~  ^
+    | [6]  [7]
+ 11 |       Wrapped text.
+    | ^~~~~~ [8]
+ 12 |
+
+Output:
+  1 | # Task list indentation
+  2 |
+  3 | -   [ ] Foo
+  4 | -   [ ] Bar
+  5 |
+  6 | *   [x] Multi line
+  7 |     text.
+  8 |
+  9 | 1.  [ ] Foo
+ 10 |     1.  [ ] FooBar
+ 11 |         Wrapped text.
+ 12 |
+
+[1] Expected indentation of 3 from the list marker but found 1.
+[2] Expected indentation of 3 from the list marker but found 1.
+[3] Expected indentation of 3 from the list marker but found 1.
+[4] Expected indentation of 4 but found 2.
+[5] Expected indentation of 2 from the list marker but found 1.
+[6] Expected indentation of 4 but found 3.
+[7] Expected indentation of 2 from the list marker but found 1.
+[8] Expected indentation of 7 but found 6.
+---
+
+
+Test: indent >> invalid >>> "# Task list indentation\n\n- [ ] Foo\n- [ ] Bar\n\n* [x] Multi line\n  text.\n\n1. [ ] Foo\n   1. [ ] FooBar\n      Wrapped text.\n 3"
+Filename: tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-end-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - listItems:
+      first: 4
+      other: first
+      relativeTo: taskListMarkerEnd
+Plugins: unable to serialize
+
+Code:
+  1 | # Task list indentation
+  2 |
+  3 | - [ ] Foo
+    |      ^ [1]
+  4 | - [ ] Bar
+    |      ^ [2]
+  5 |
+  6 | * [x] Multi line
+    |      ^ [3]
+  7 |   text.
+    | ^~ [4]
+  8 |
+  9 | 1. [ ] Foo
+    |       ^ [5]
+ 10 |    1. [ ] FooBar
+    | ^~~ [6]  ^ [7]
+ 11 |       Wrapped text.
+    | ^~~~~~ [8]
+ 12 |
+
+Output:
+  1 | # Task list indentation
+  2 |
+  3 | - [ ]    Foo
+  4 | - [ ]    Bar
+  5 |
+  6 | * [x]    Multi line
+  7 |          text.
+  8 |
+  9 | 1. [ ]    Foo
+ 10 |       1. [ ]    FooBar
+ 11 |                 Wrapped text.
+ 12 |
+
+[1] Expected indentation of 4 from the list marker but found 1.
+[2] Expected indentation of 4 from the list marker but found 1.
+[3] Expected indentation of 4 from the list marker but found 1.
+[4] Expected indentation of 9 but found 2.
+[5] Expected indentation of 4 from the list marker but found 1.
+[6] Expected indentation of 6 but found 3.
+[7] Expected indentation of 4 from the list marker but found 1.
+[8] Expected indentation of 13 but found 6.
+---
+
+
+Test: indent >> invalid >>> "# Task list indentation\n\n- [ ] Foo\n- [ ] Bar\n\n* [x] Multi line\n  text.\n\n1. [ ] Foo\n   1. [ ] FooBar\n      Wrapped text.\n 4"
+Filename: tests/fixtures/rules/indent/invalid/task-list-relative-to/first-4-task-list-marker-start-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - listItems:
+      first: 4
+      other: first
+      relativeTo: taskListMarkerStart
+Plugins: unable to serialize
+
+Code:
+  1 | # Task list indentation
+  2 |
+  3 | - [ ] Foo
+  4 | - [ ] Bar
+  5 |
+  6 | * [x] Multi line
+  7 |   text.
+    | ^~ [1]
+  8 |
+  9 | 1. [ ] Foo
+ 10 |    1. [ ] FooBar
+    | ^~~ [2]
+ 11 |       Wrapped text.
+    | ^~~~~~ [3]
+ 12 |
+
+Output:
+  1 | # Task list indentation
+  2 |
+  3 | - [ ] Foo
+  4 | - [ ] Bar
+  5 |
+  6 | * [x] Multi line
+  7 |       text.
+  8 |
+  9 | 1. [ ] Foo
+ 10 |       1. [ ] FooBar
+ 11 |              Wrapped text.
+ 12 |
+
+[1] Expected indentation of 6 but found 2.
+[2] Expected indentation of 6 but found 3.
+[3] Expected indentation of 10 but found 6.
+---
+
+
+Test: indent >> invalid
+Filename: tests/fixtures/rules/indent/invalid/task-list-relative-to/first-ignore-marker-end-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - listItems:
+      first: ignore
+      other: first
+      relativeTo: markerEnd
+Plugins: unable to serialize
+
+Code:
+  1 | # Task list indentation with an ignored first line
+  2 |
+  3 | -    [x] Multi line
+  4 |   text.
+    | ^~ [1]
+  5 |
+  6 | 1.   [ ] Multi line
+  7 |        text.
+    | ^~~~~~~ [2]
+  8 |
+
+Output:
+  1 | # Task list indentation with an ignored first line
+  2 |
+  3 | -    [x] Multi line
+  4 |      text.
+  5 |
+  6 | 1.   [ ] Multi line
+  7 |      text.
+  8 |
+
+[1] Expected indentation of 5 but found 2.
+[2] Expected indentation of 5 but found 7.
+---
+
+
+Test: indent >> invalid
+Filename: tests/fixtures/rules/indent/invalid/task-list-relative-to/other-4-task-list-marker-start-input.md
+Language: markdown-preferences/extended-syntax
+LanguageOptions:
+  frontmatter: yaml
+Options:
+  - listItems:
+      first: 1
+      other: 4
+      relativeTo: taskListMarkerStart
+Plugins: unable to serialize
+
+Code:
+  1 | # Task list indentation for lines after the first
+  2 |
+  3 | - [ ] Multi line
+  4 |   text.
+    | ^~ [1]
+  5 |
+  6 | 1. [ ] Multi line
+  7 |    text.
+    | ^~~ [2]
+  8 |
+
+Output:
+  1 | # Task list indentation for lines after the first
+  2 |
+  3 | - [ ] Multi line
+  4 |       text.
+  5 |
+  6 | 1. [ ] Multi line
+  7 |        text.
+  8 |
+
+[1] Expected indentation of 6 but found 2.
+[2] Expected indentation of 7 but found 3.
+---
+
+
+Test: indent >> invalid
 Filename: tests/fixtures/rules/indent/invalid/thematic-breaks-input.md
 Language: markdown-preferences/extended-syntax
 LanguageOptions:


### PR DESCRIPTION
Prevent crashes in `markdown-preferences/indent` when task list items use `relativeTo` values other than `taskListMarkerEnd` by calculating indentation from the configured reference point. Also implement and document `taskListMarkerStart` behavior and correct the documented default to `taskListMarkerEnd`.

Fix #322